### PR TITLE
Make Mandrill _id available via event.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.4.4",
-        "phpunit/phpunit": "^9.5.10"
+        "phpunit/phpunit": "^9.5.10",
+        "orchestra/testbench": "^8.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4.4",
         "phpunit/phpunit": "^9.5.10",
-        "orchestra/testbench": "^8.1"
+        "orchestra/testbench": "^v7.24"
     },
     "autoload": {
         "psr-4": {

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -35,7 +35,7 @@ class MandrillTransport extends AbstractTransport
 
         // If Mandrill _id was returned, set it as the message id for
         // use elsewhere in the platform.
-        if (!empty($data->_id)){
+        if (!empty($data->_id)) {
             $message->setMessageId($data->_id);
         }
     }
@@ -115,14 +115,14 @@ class MandrillTransport extends AbstractTransport
 
     /**
      * Replace Mandrill client.
-     * Currently implemented for testing but would allow custom guzzle configurations to be
-     * set into the mandrill library (e.g. proxying config)
+     * This is used primarily for testing but could in theory allow other use cases
+     * e.g. Configuring proxying in Guzzle.
      * 
      * @param ApiClient $client [description]
+     * @return void
      */
     public function setClient(ApiClient $client): void
     {
         $this->mailchimp = $client;
     }
-
 }

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -49,12 +49,12 @@ class MandrillTransport extends AbstractTransport
 
         // If Mandrill _id was returned, set it as the message id for
         // use elsewhere in the application.
-        if (!empty($data->_id)) {
-            $message->setMessageId($data->_id);
+        if (!empty($data[0]?->_id)) {
+            $messageId = $data[0]->_id;
+            $message->setMessageId($messageId);
             // Convention seems to be to set this header on the original for access later.
-            $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $data->_id);
+            $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $messageId);
         }
-
     }
 
     /**

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -48,7 +48,7 @@ class MandrillTransport extends AbstractTransport
         ]);
 
         // If Mandrill _id was returned, set it as the message id for
-        // use elsewhere in the platform.
+        // use elsewhere in the application.
         if (!empty($data->_id)) {
             $message->setMessageId($data->_id);
             // Convention seems to be to set this header on the original for access later.

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -27,11 +27,17 @@ class MandrillTransport extends AbstractTransport
     {
         $message = $this->setHeaders($message);
 
-        $this->mailchimp->messages->sendRaw([
+        $data = $this->mailchimp->messages->sendRaw([
             'raw_message' => $message->toString(),
             'async' => true,
             'to' => $this->getTo($message),
         ]);
+
+        // If Mandrill _id was returned, set it as the message id for
+        // use elsewhere in the platform.
+        if (!empty($data->_id)){
+            $message->setMessageId($data->_id);
+        }
     }
 
     /**
@@ -106,4 +112,17 @@ class MandrillTransport extends AbstractTransport
     {
         return 'mandrill';
     }
+
+    /**
+     * Replace Mandrill client.
+     * Currently implemented for testing but would allow custom guzzle configurations to be
+     * set into the mandrill library (e.g. proxying config)
+     * 
+     * @param ApiClient $client [description]
+     */
+    public function setClient(ApiClient $client): void
+    {
+        $this->mailchimp = $client;
+    }
+
 }

--- a/tests/MandrillTransportTest.php
+++ b/tests/MandrillTransportTest.php
@@ -45,9 +45,11 @@ class MailerSendTransportTest extends TestCase
             new Response(200, 
                 ['content-type' => 'application/json'], 
                 json_encode([
-                    "email" => "testemail@example.com",
-                    "status" => "queued",
-                    "_id" => "111111111111111"
+                    [
+                        "email" => "testemail@example.com",
+                        "status" => "queued",
+                        "_id" => "111111111111111"
+                    ]
                 ])
             )
         ]);
@@ -93,9 +95,11 @@ class MailerSendTransportTest extends TestCase
             new Response(200, 
                 ['content-type' => 'application/json'], 
                 json_encode([
-                    "email" => "testemail@example.com",
-                    "status" => "queued",
-                    "_id" => "111111111111111"
+                    [
+                        "email" => "testemail@example.com",
+                        "status" => "queued",
+                        "_id" => "111111111111111"
+                    ]
                 ])
             )
         ]);

--- a/tests/MandrillTransportTest.php
+++ b/tests/MandrillTransportTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace LaravelMandrill\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use Illuminate\Mail\Mailable;
+use GuzzleHttp\Psr7\Response;
+use Orchestra\Testbench\TestCase;
+use GuzzleHttp\Handler\MockHandler;
+use Illuminate\Support\Facades\Mail;
+use MailchimpTransactional\ApiClient;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Mail\Events\MessageSent;
+
+class MailerSendTransportTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            'LaravelMandrill\MandrillServiceProvider',
+        ];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        // Setup default database to use sqlite :memory:
+        $app['config']->set('mail.driver', 'mandrill');
+
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function mockMandrillAPiResponces(MockHandler $handler)
+    {
+        // Inject a mocked instance of guzzel into the underlying mandrill transport.
+        // This will allow us to test the mail fully.
+        $mockApiClient = new class($handler) extends ApiClient {
+            public function __construct($handler)
+            {
+                parent::__construct();
+
+                // Swap in mocked Guzzle instance
+                $this->requestClient = new Client([
+                    'handler' => HandlerStack::create($handler)
+                ]);
+            }
+        };
+
+        Mail::getFacadeRoot()->mailer('mandrill')->getSymfonyTransport()->setClient($mockApiClient);
+    }
+
+
+    public function testRun()
+    {
+        // Mock API for successful email send
+        $mock = new MockHandler([
+            new Response(200, 
+                ['content-type' => 'application/json'], 
+                json_encode([
+                    "email" => "testemail@example.com",
+                    "status" => "queued",
+                    "_id" => "111111111111111"
+                ])
+            )
+        ]);
+
+        // Mock Mandrill API
+        $this->mockMandrillAPiResponces($mock);
+
+        // Setup test email.
+        $testMail = new class() extends Mailable {
+            public function build()
+            {
+                return $this->from('mandrill@test.com', 'Test') ->html('Hello World');
+            }
+        };
+
+        // Ensure event contains expected data.
+        Event::listen(MessageSent::class, function($event)
+        {
+            // Check Mandrill _id was passed back
+            $this->assertEquals($event->sent->getMessageId(), "111111111111111");
+            // Check correct from email.
+            $this->assertEquals($event->message->getFrom()[0]->getAddress(), "mandrill@test.com");
+            // Check correct to email.
+            $this->assertEquals($event->message->getTo()[0]->getAddress(), "testemail@example.com");
+        });
+
+        // Trigger event
+        Mail::to('testemail@example.com')->send($testMail);
+    }
+}


### PR DESCRIPTION
This PR is just for visibility. Will PR upstream once complete.

Make the Mandrill message `id` accessible from the Laravel via the sent event. Message id is now available via
*  the `sentMessage` messageId property. `e.g. $event->sent->getMessageId()`
* the `X-Message-ID` header `$event->message->getHeaders()->get('X-Message-ID')`

The `X-Message-ID`  convention is taken from Laravel maintained mail drivers including the base SES driver.

Additionally fixes headers not being sent as part of the Mail payload, causing `X-MC-Subaccount` and similar headers not to work as expected. 

In theory this should resolve https://github.com/luisdalmolin/laravel-mandrill-driver/issues/30 and https://github.com/luisdalmolin/laravel-mandrill-driver/issues/31

Unit tests for the message _id retrieval and header submission have been added. This did require a minor change to the Transport in order to facilitate mocking of the underlying Guzzle instance.
